### PR TITLE
Add Banorte Payworks template to admin panel

### DIFF
--- a/app/views/spree/admin/payments/source_forms/_banortepayworks.html.erb
+++ b/app/views/spree/admin/payments/source_forms/_banortepayworks.html.erb
@@ -1,0 +1,58 @@
+<div class="row">
+  <div class="col-md-6">
+    <ul class="paymethod-list credit-card-types">
+      <li class="paymethod-list__item"><i class="fa fa-cc-visa" aria-hidden="true"></i></li>
+      <li class="paymethod-list__item"><i class="fa fa-cc-mastercard" aria-hidden="true"></i></li>
+    </ul>
+    <% param_prefix = "payment_source[#{payment_method.id}]" %>
+
+    <p class="field">
+      <%= text_field_tag "#{param_prefix}[name]",
+                         "#{@order.billing_firstname} #{@order.billing_lastname}",
+                         { id: "name_on_card_#{payment_method.id}",
+                           placeholder: Spree.t(:name_on_card),
+                           required: true} %>
+    </p>
+
+    <p class="field" data-hook="card_number">
+      <% options_hash = Rails.env.production? ? {autocomplete: 'off'} : {} %>
+      <%= text_field_tag "#{param_prefix}[number]",
+                         '',
+                         options_hash.merge(:id => 'card_number',
+                                            class: 'required cardNumber',
+                                            size: 19,
+                                            maxlength: 19,
+                                            autocomplete: "off",
+                                            placeholder: Spree.t(:card_number)) %>
+      &nbsp;
+      <span id="card_type" style="display:none;">
+        ( <span id="looks_like" ><%= Spree.t(:card_type_is) %> <span id="type"></span></span>
+          <span id="unrecognized"><%= Spree.t(:unrecognized_card_type) %></span>
+        )
+      </span>
+    </p>
+
+    <p class="field" data-hook="card_expiration">
+      <%= select_month(Date.today,
+                       { prefix: param_prefix, field_name: 'month', use_month_numbers: true },
+                       class: 'required',
+                       id: "card_month",
+                       placeholder: Spree.t(:expiration)) %>
+
+      <%= select_year(Date.today,
+                      { prefix: param_prefix, field_name: 'year', start_year: Date.today.year, end_year: Date.today.year + 15 },
+                      class: 'required',
+                      id: "card_year") %>
+    </p>
+
+    <p class="field" data-hook="card_code">
+      <%= text_field_tag "#{param_prefix}[verification_value]",
+                         '',
+                         options_hash.merge(id: 'card_code',
+                                            class: 'required cardCode',
+                                            size: 5,
+                                            placeholder: Spree.t(:card_code)) %>
+      <%= link_to "(#{Spree.t(:what_is_this)})", spree.cvv_path, target: '_blank', "data-hook" => "cvv_link", id: "cvv_link" %>
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
This template allows the admin to pay a completed order using Banorte Payworks payment method from the Solidus Admin Panel.

## Result
![screenshot_2018-09-25 nuevo pago - pagos - r925011519 - pedidos](https://user-images.githubusercontent.com/21062088/46022757-ce1f5a00-c0a8-11e8-8ede-7aef775eaac2.png)
