### PR TITLE
Freeze PAYWORKS constant

### DIFF
--- a/app/models/spree/gateway/banorte_payworks2.rb
+++ b/app/models/spree/gateway/banorte_payworks2.rb
@@ -2,7 +2,7 @@ module Spree
   class Gateway::BanortePayworks2 < ::Spree::CreditCard
     attr_accessor :server, :test_mode, :merchant_id, :user, :password, :terminal_id
 
-    BANORTE_PAYWORKS_URL = 'https://via.pagosbanorte.com/payw2'
+    BANORTE_PAYWORKS_URL = 'https://via.pagosbanorte.com/payw2'.freeze
 
     def purchase(amount, source, gateway_options)
       payload = {


### PR DESCRIPTION
Hey there!

Probably this doesn't add value to your project, but I noticed you are using the payworks base url as a constant but it stills mutable. According to this https://blog.honeybadger.io/when-to-use-freeze-and-frozen-in-ruby/ is a good practice to use freeze to create a constant that's actually constant.